### PR TITLE
Update module-info.java to use com.azure.core.v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Azure Code Migration with OpenRewrite
 This repository showcases the integration of OpenRewrite with Maven for code migration purposes.
-The migration recipe is defined to transition from `azure-core` to `azure-core-v2` libraries.
+The migration recipe is defined to transition from `azure-core` to `azure-core-v2` libraries. 
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ recipeList:
 ```
 You can find the recipe configuration in the `rewrite.yml` file [here]().
 
+
 ## Usage
 ### Maven Plugin Configuration
 The OpenRewrite Maven plugin is configured in the `java-rewrite-core` module to run the migration recipe on the sample project

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Azure Code Migration with OpenRewrite
-This repository showcases the integration of OpenRewrite with Maven for code migration purposes.
-
-The migration recipe is defined to transition from `azure-core` to `azure-core-v2` libraries.
+This repository showcases the integration of OpenRewrite with Maven for code migration purposes. The migration recipe is defined to transition from `azure-core` to `azure-core-v2` libraries.
 
 ## Setup 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Azure Code Migration with OpenRewrite
-This repository showcases the integration of OpenRewrite with Maven for code migration purposes. The migration recipe is defined to transition from `azure-core` to `azure-core-v2` libraries.
+
+This repository showcases the integration of OpenRewrite with Maven for code migration purposes.
+The migration recipe is defined to transition from `azure-core` to `azure-core-v2` libraries.
 
 ## Setup 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This repository showcases the integration of OpenRewrite with Maven for code migration purposes.
 The migration recipe is defined to transition from `azure-core` to `azure-core-v2` libraries. 
 
-## Setup
+## Setup 
 
 The migration recipe is defined in the `java-rewrite-core` module as detailed below:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Azure Code Migration with OpenRewrite
 
 This repository showcases the integration of OpenRewrite with Maven for code migration purposes.
-The migration recipe is defined to transition from `azure-core` to `azure-core-v2` libraries.
+The migration recipe is defined to transition from `azure-core` to `azure-core-v2` libraries
 
 ## Setup 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Azure Code Migration with OpenRewrite
 This repository showcases the integration of OpenRewrite with Maven for code migration purposes.
-The migration recipe is defined to transition from `azure-core` to `azure-core-v2` libraries. 
+
+The migration recipe is defined to transition from `azure-core` to `azure-core-v2` libraries.
 
 ## Setup 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Azure Code Migration with OpenRewrite
 
 This repository showcases the integration of OpenRewrite with Maven for code migration purposes.
-The migration recipe is defined to transition from `azure-core` to `azure-core-v2` libraries
+The migration recipe is defined to transition from `azure-core` to `azure-core-v2` libraries.
 
 ## Setup 
 

--- a/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -8,10 +8,7 @@ recipeList:
       newPackageName: io.clientcore
       recursive: true
   - org.openrewrite.text.FindAndReplace:
-      find: 'requires com.azure.core'
-      replace: 'requires com.azure.core.v2'
-      filePattern: '**/module-info.java'
-  - org.openrewrite.text.FindAndReplace:
-      find: 'requires transitive com.azure.core'
-      replace: 'requires transitive com.azure.core.v2'
+      regex: true
+      find: 'requires\s+(transitive\s+)?com\.azure\.core(?!\.v2)'
+      replace: 'requires $1com.azure.core.v2'
       filePattern: '**/module-info.java'

--- a/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -7,3 +7,11 @@ recipeList:
       oldPackageName: com.azure
       newPackageName: io.clientcore
       recursive: true
+  - org.openrewrite.text.FindAndReplace:
+      find: 'requires com.azure.core'
+      replace: 'requires com.azure.core.v2'
+      filePattern: '**/module-info.java'
+  - org.openrewrite.text.FindAndReplace:
+      find: 'requires transitive com.azure.core'
+      replace: 'requires transitive com.azure.core.v2'
+      filePattern: '**/module-info.java'

--- a/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -3,10 +3,6 @@ name: com.azure.rewrite.java.core.MigrateAzureCoreSamplesToAzureCoreV2
 displayName: Migrate azure-core samples to azure-core-v2
 description: This recipe migrates the samples in azure-core to azure-core-v2
 recipeList:
-  - org.openrewrite.java.ChangePackage:
-      oldPackageName: com.azure
-      newPackageName: io.clientcore
-      recursive: true
   - org.openrewrite.text.FindAndReplace:
       regex: true
       find: 'requires\s+(transitive\s+)?com\.azure\.core(?!\.v2)'


### PR DESCRIPTION
**List of change in this PR:** 

- Added recipe to rewrite.yml to change `requires com.azure.core` to `requires com.azure.core.v2` in `module-info.java`  and `requires transitive com.azure.core` to `requires transitive com.azure.core.v2` in `module-info.java`
- Removed example recipe

OpenRewrite's FindAndReplace recipe for changing plain text was used due to OpenRewrite's lack of support for converting Java module declarations to LSTs.

Note: This pull request contains identical code changes to https://github.com/Azure/azsdk-java-rewrite-recipes/pull/6. However, this PR has the correct source branch.